### PR TITLE
fix(lint): clear CI eslint errors

### DIFF
--- a/packages/automations/src/AutomationListPage.tsx
+++ b/packages/automations/src/AutomationListPage.tsx
@@ -1,6 +1,5 @@
 import {
   DotsThreeIcon,
-  PlusIcon,
   ClockIcon,
   LightningIcon,
   RobotIcon,

--- a/packages/server/src/lib/automation-executor.ts
+++ b/packages/server/src/lib/automation-executor.ts
@@ -112,7 +112,7 @@ async function deliverRunArtifacts(
   if (!attachments.length) return;
 
   const names = attachments.map((a) => a.filename).join(", ");
-  console.log(`[artifact-delivery] emailing ${attachments.length} file(s) (${names}) to ${to} for automation ${ruleKey}`);
+  console.warn(`[artifact-delivery] emailing ${attachments.length} file(s) (${names}) to ${to} for automation ${ruleKey}`);
   const res = await fetch(`${env.BASICSOS_API_URL}/v1/email/send`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },

--- a/packages/server/src/routes/me.ts
+++ b/packages/server/src/routes/me.ts
@@ -22,7 +22,7 @@ const isValidTz = (tz: string): boolean => {
   }
 };
 
-export function createMeRoutes(db: Db, auth: Auth, env: Env) {
+export function createMeRoutes(db: Db, auth: Auth, _env: Env) {
   const app = new Hono();
 
   /** Effective timezone (the user's, the org default, and what actually applies). */

--- a/src/components/pages/ObjectListPage.tsx
+++ b/src/components/pages/ObjectListPage.tsx
@@ -43,10 +43,7 @@ import { useEmailSyncStatus } from "@/hooks/use-email-sync";
 import { SuggestedContactsSheet } from "@/components/email-sync/SuggestedContactsSheet";
 import { FindFromEmailDialog } from "@/components/email-sync/FindFromEmailDialog";
 import { SparkleIcon, XIcon, BuildingsIcon } from "@phosphor-icons/react";
-import {
-  ContextMenuItem,
-  ContextMenuSeparator,
-} from "@/components/ui/context-menu";
+import { ContextMenuItem } from "@/components/ui/context-menu";
 import { Button } from "@/components/ui/button";
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
Fixes the 4 eslint errors from the CI lint run:
- AutomationListPage: unused `PlusIcon` import removed
- automation-executor: `console.log` → `console.warn`
- me.ts: unused `env` param → `_env`
- ObjectListPage: unused `ContextMenuSeparator` import removed

Verified locally: `eslint **/*.{mjs,ts,tsx}` (excluding the untracked `services/hermes/vendor/**`, which CI doesn't have) → 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpqGPdvrUnzBSMnYL2181o